### PR TITLE
Optional pull - Install scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 node_modules/
 java-twitter-feed-api/target/
+installscripts/0.sh

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ This repo demonstrates simple development and deployment of polyglot microservic
 
 
 
-![alt tag](https://raw.githubusercontent.com/debianmaster/microservices-on-openshift/master/Arch.png)
+![alt tag](https://raw.githubusercontent.com/veermuchandi/microservices-on-openshift/master/Arch.png)
 
 > This is how it looks at the end   
 
 
-![alt tag](https://raw.githubusercontent.com/debianmaster/Notes/master/demogif-latest.gif)
+![alt tag](https://raw.githubusercontent.com/veermuchandi/Notes/master/demogif-latest.gif)
 
 
 # 
@@ -88,7 +88,7 @@ MYSQL_USER='app_user'\
 MYSQL_PASSWORD='password'\
 MYSQL_DATABASE='microservices'\
 MYSQL_SERVICE_HOST='MYSQL'\
-  https://github.com/debianmaster/microservices-on-openshift.git \
+  https://github.com/veermuchandi/microservices-on-openshift.git \
   --name=emailsvc --image-stream='python:2.7'  -l microservice=emailsvc
 ```
 
@@ -116,7 +116,7 @@ oc new-app -e EMAIL_APPLICATION_DOMAIN=http://emailsvc:8080 \
 MONGODB_DATABASE=userdb MONGODB_PASSWORD=password \
 MONGODB_USER=mongouser DATABASE_SERVICE_NAME=mongodb \
 --context-dir='nodejs-users-api' \
-https://github.com/debianmaster/microservices-on-openshift.git \
+https://github.com/veermuchandi/microservices-on-openshift.git \
 --name='userregsvc' -l microservice=userregsvc
 
 oc expose svc/userregsvc
@@ -132,7 +132,7 @@ This microservice is a java application which takes twitter username as input an
 oc import-image --from=registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift tomcat8 --confirm
 
 oc new-app \
-https://github.com/debianmaster/microservices-on-openshift.git \
+https://github.com/veermuchandi/microservices-on-openshift.git \
 --context-dir='java-twitter-feed-api' \
 --image-stream='tomcat8'  \
 --name='twitter-api' -l microservice=twittersvc
@@ -150,7 +150,7 @@ Note that we are setting an environment variable for userregsvc to access the ba
 $ oc new-app -e USER_REG_SVC="http://userregsvc-$OSE_PROJECT.$OSE_DOMAIN" \
 -e TWITTER_FEED_SVC="http://twitter-api-$OSE_PROJECT.$OSE_DOMAIN" \
 --context-dir='php-ui' \
-https://github.com/debianmaster/microservices-on-openshift.git \
+https://github.com/veermuchandi/microservices-on-openshift.git \
 --name='userreg' \
 -l microservice=userreg
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,20 @@ This repo demonstrates simple development and deployment of polyglot microservic
 
 
 # 
+
 ## 0. Initial Setup
 > To setup openshift on your laptop using a Vagrant image use https://www.openshift.org/vm/
 > Assuming you have openshift installed on https://10.2.2.2:8443
 
 Create an OpenShift project where these microservices will be created for development purposes. As an example we are calling it msdev.
-```sh
+
+
+```
 oc login https://10.2.2.2:8443   
 oc new-project msdev
 ```
+
+**Note:** If you want to quickly deploy these microservices you can use the install scripts. [Read here](installscripts/readme.md)
 
 If you wish to change the code, feel free to fork the code and use your git links instead.
 
@@ -38,6 +43,7 @@ export OSE_PROJECT=<<your openshift projectname. ex:msdev>
 Ex:--   
 `$ export OSE_DOMAIN=apps.10.2.2.2.xip.io`  
 `$ export OSE_PROJECT=msdev`  
+
 
 ## 1. Create the Email Micro Service
 > Python application  

--- a/installscripts/1.setVariable.sh
+++ b/installscripts/1.setVariable.sh
@@ -2,7 +2,6 @@ export OSE_DOMAIN=apps.devday.ocpcloud.com
 export OSE_CLIENT_PROJECT=msservices
 export OSE_SERVICES_PROJECT=msservices
 export OSE_INFRA_PROJECT=msservices
-export OSE_SERVICESROJECT=msclient
 export FROM_GMAIL=<<from email for your email service>>
 export FROM_GMAIL_PASSWORD=<<password for the from email>>
 //For these params refer https://dev.twitter.com/oauth/overview/application-owner-access-tokens

--- a/installscripts/1.setVariable.sh
+++ b/installscripts/1.setVariable.sh
@@ -1,0 +1,13 @@
+export OSE_DOMAIN=apps.devday.ocpcloud.com
+export OSE_CLIENT_PROJECT=msservices
+export OSE_SERVICES_PROJECT=msservices
+export OSE_INFRA_PROJECT=msservices
+export OSE_SERVICESROJECT=msclient
+export FROM_GMAIL=<<from email for your email service>>
+export FROM_GMAIL_PASSWORD=<<password for the from email>>
+//For these params refer https://dev.twitter.com/oauth/overview/application-owner-access-tokens
+export TWITTER_CONSUMER_KEY=<<Consumer Key (API Key)>>
+export TWITTER_CONSUMER_SECRET=<<Consumer Secret (API Secret)>>
+export TWITTER_OAUTH_ACCESS_TOKEN=<<Access Token>>
+export TWITTER_OAUTH_ACCESS_TOKEN_SECRET=<<Access Token Secret>>
+

--- a/installscripts/2.deployEmailSvc-PythonMySQL.sh
+++ b/installscripts/2.deployEmailSvc-PythonMySQL.sh
@@ -1,0 +1,26 @@
+oc project $OSE_INFRA_PROJECT
+oc new-app -e MYSQL_USER='app_user' \
+MYSQL_PASSWORD='password' \
+MYSQL_DATABASE=microservices \
+ registry.access.redhat.com/rhscl/mysql-56-rhel7 --name='mysql' -l microservice=emailsvc
+
+sleep 10
+
+oc deploy mysql --cancel
+
+oc patch dc/mysql --patch '{"spec":{"strategy":{"rollingParams":{"post":{"failurePolicy": "ignore","execNewPod":{"containerName":"mysql","command":["/bin/sh","-c","hostname&&sleep 10&&echo $QUERY | /opt/rh/rh-mysql56/root/usr/bin/mysql -h $MYSQL_SERVICE_HOST -u $MYSQL_USER -D $MYSQL_DATABASE -p$MYSQL_PASSWORD -P 3306"], "env": [{"name": "QUERY", "value":"CREATE TABLE IF NOT EXISTS emails \u0028from_add varchar\u002840\u0029,to_add varchar\u002840\u0029, subject varchar\u002840\u0029, body varchar\u0028200\u0029, created_at date\u0029;"}]}}}}}}'
+
+oc rollout latest mysql
+
+oc new-app --context-dir='python-email-api' \
+  -e EMAIL_APPLICATION_DOMAIN=http://emailsvc:8080 \
+MYSQL_USER='app_user' \
+MYSQL_PASSWORD='password' \
+MYSQL_DATABASE='microservices' \
+MYSQL_SERVICE_HOST='MYSQL' \
+  https://github.com/veermuchandi/microservices-on-openshift.git \
+  --name=emailsvc --image-stream='python:2.7'  -l microservice=emailsvc
+
+oc create configmap email-props --from-literal=GMAIL_USERNAME=$FROM_GMAIL --from-literal=GMAIL_PASSWORD=$FROM_GMAIL_PASSWORD
+oc env dc/emailsvc --from=configmap/email-props 
+

--- a/installscripts/3.deployTwitter-Tomcat.sh
+++ b/installscripts/3.deployTwitter-Tomcat.sh
@@ -1,0 +1,18 @@
+oc project $OSE_SERVICES_PROJECT
+oc import-image --from=registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat8-openshift tomcat8 --confirm
+
+oc new-app \
+https://github.com/veermuchandi/microservices-on-openshift.git \
+--context-dir='java-twitter-feed-api' \
+--image-stream='tomcat8'  \
+--name='twitter-api' -l microservice=twittersvc
+
+oc create configmap twitter-props \
+ --from-literal=TWITTER_CONSUMER_KEY=$TWITTER_CONSUMER_KEY \
+ --from-literal=TWITTER_CONSUMER_SERVICE=$TWITTER_CONSUMER_SECRET \
+ --from-literal=TWITTER_OAUTH_ACCESS_TOKEN=$TWITTER_OAUTH_ACCESS_TOKEN \
+ --from-literal=TWITTER_OAUTH_ACCESS_TOKEN_SECRET=$TWITTER_OAUTH_ACCESS_TOKEN_SECRET
+
+oc env dc/twitter-api --from=configmap/twitter-props
+
+oc expose svc/twitter-api

--- a/installscripts/4.deployUserRegBackend-NodejsMongo.sh
+++ b/installscripts/4.deployUserRegBackend-NodejsMongo.sh
@@ -1,0 +1,19 @@
+oc project $OSE_SERVICES_PROJECT
+
+export EMAIL_SERVICE_URL="http://emailsvc."$OSE_INFRA_PROJECT":8080"
+
+oc new-app -e MONGODB_USER=mongouser MONGODB_PASSWORD=password \
+MONGODB_DATABASE=userdb MONGODB_ADMIN_PASSWORD=password \
+  registry.access.redhat.com/rhscl/mongodb-26-rhel7 \
+--name mongodb -l microservice=userregsvc
+
+oc deploy mongodb --latest
+
+oc new-app -e EMAIL_APPLICATION_DOMAIN=$EMAIL_SERVICE_URL \
+MONGODB_DATABASE=userdb MONGODB_PASSWORD=password \
+MONGODB_USER=mongouser DATABASE_SERVICE_NAME=mongodb \
+--context-dir='nodejs-users-api' \
+https://github.com/debianmaster/microservices-on-openshift.git \
+--name='userregsvc' -l microservice=userregsvc
+
+oc expose svc/userregsvc

--- a/installscripts/5.deployFrontend-PHP.sh
+++ b/installscripts/5.deployFrontend-PHP.sh
@@ -1,0 +1,8 @@
+oc project $OSE_CLIENT_PROJECT
+oc new-app -e USER_REG_SVC="http://userregsvc-$OSE_SERVICES_PROJECT.$OSE_DOMAIN" \
+-e TWITTER_FEED_SVC="http://twitter-api-$OSE_SERVICES_PROJECT.$OSE_DOMAIN" \
+--context-dir='php-ui' \
+https://github.com/veermuchandi/microservices-on-openshift.git \
+--name='userreg' \
+-l microservice=userreg
+oc expose svc/userreg

--- a/installscripts/readme.md
+++ b/installscripts/readme.md
@@ -1,0 +1,50 @@
+# Quick Install Scripts
+
+If you want to quickly deploy these microservices independently without using  templates, you can use the following scripts.
+
+Once you clone the repository, navigate to `installscripts` folder. Run the scripts in order.
+
+[1.setVariable.sh](1.setVariable.sh) This script sets all the environment variables needed by your services. Edit this script first.
+	
+* Create a project to deploy microservices (`oc new-project mstest`) and use the same projectName (example `mstest`) as the value for three variables `OSE_CLIENT_PROJECT`, `OSE_SERVICES_PROJECT` and `OSE_INFRA_PROJECT`. For more complex deployments where you want to separate this application into distinct projects these variables may gave separate values. 
+*  `OSE_DOMAIN` is the domain name or the wildcard DNS for your openshift setup. 
+*  `FROM_GMAIL` and `FROM_GMAIL_PASSWORD` are the values for the gmail account to use by the email service. Email service requires a gmail account to use to send emails from. So create an email account and add the values for these variables.
+*  `TWITTER_CONSUMER_KEY`, `TWITTER_CONSUMER_SECRET`, `TWITTER_OAUTH_ACCESS_TOKEN`, `TWITTER_OAUTH_ACCESS_TOKEN_SECRET` are the credentials required by the Twitter service to pull the tweets. Refer the documentation here [https://dev.twitter.com/oauth/overview/application-owner-access-tokens](https://dev.twitter.com/oauth/overview/application-owner-access-tokens)
+
+Once the values are assigned to environment variables, run this script as follows to set the values to the environment variables. 	
+```
+source 1.setVariable.sh
+```
+		
+[2.deployEmailSvc-PythonMySQL.sh](2.deployEmailSvc-PythonMySQL.sh)
+This script deploys email service written in python that uses MySQL database to store the emails. The gmail credentials required by this service are added as a configmap and assigned to the environment variables used by the python code. Run this code as follows
+
+```
+source 2.deployEmailSvc-PythonMySQL.sh
+```
+
+[3.deployTwitter-Tomcat.sh](3.deployTwitter-Tomcat.sh)
+This script deploys the Twitter service written in Java. This service requires connection to Twitter. Twitter credentials are added as a configmap and are configured as environment variables that get the values from configmap. Run the script as follows
+
+```
+source 3.deployTwitter-Tomcat.sh
+```
+
+
+[4.deployUserRegBackend-NodejsMongo.sh](4.deployUserRegBackend-NodejsMongo.sh)
+This script deploys the UserRegistration backed that is written in NodeJS. The data is saved to a MongoDB.
+
+```
+source 4.deployUserRegBackend-NodejsMongo.sh
+```
+
+[5.deployFrontend-PHP.sh](5.deployFrontend-PHP.sh)
+This script deploys front-end microservice written in PHP. The resultant application should make REST calls to UserRegistration backend, and Twitter services.
+
+```
+source 5.deployFrontend-PHP.sh
+```
+
+
+
+

--- a/installscripts/x.cleanup
+++ b/installscripts/x.cleanup
@@ -1,3 +1,6 @@
 oc delete all --all -n $OSE_CLIENT_PROJECT
 oc delete all --all -n $OSE_SERVICES_PROJECT
 oc delete all --all -n $OSE_INFRA_PROJECT
+oc delete configmap --all -n $OSE_CLIENT_PROJECT
+oc delete configmap --all -n $OSE_SERVICES_PROJECT
+oc delete configmap --all -n $OSE_INFRA_PROJECT

--- a/installscripts/x.cleanup
+++ b/installscripts/x.cleanup
@@ -1,0 +1,3 @@
+oc delete all --all -n $OSE_CLIENT_PROJECT
+oc delete all --all -n $OSE_SERVICES_PROJECT
+oc delete all --all -n $OSE_INFRA_PROJECT

--- a/php-ui/hack.php
+++ b/php-ui/hack.php
@@ -2,7 +2,7 @@
 $dbhost = gethostbyname('mysql.msservices'); 
 $dbport = 3306;
 $dbuser = "app_user";
-$dbname = "microservices"
+$dbname = "microservices";
 $dbpwd = "password";
  
 $connection = mysqli_connect($dbhost.":".$dbport, $dbuser, $dbpwd, $dbname) or die("Error " . mysqli_error($connection));

--- a/php-ui/hack.php
+++ b/php-ui/hack.php
@@ -1,5 +1,5 @@
 <?php
-$dbhost = gethostbyname('mysql.msservices'); 
+$dbhost = gethostbyname('mysql.msinfra'); 
 $dbport = 3306;
 $dbuser = "app_user";
 $dbname = "microservices";

--- a/php-ui/hack.php
+++ b/php-ui/hack.php
@@ -1,0 +1,17 @@
+<?php
+$dbhost = gethostbyname('mysql.msservices'); 
+$dbport = 3306;
+$dbuser = "app_user";
+$dbname = "microservices"
+$dbpwd = "password";
+ 
+$connection = mysqli_connect($dbhost.":".$dbport, $dbuser, $dbpwd, $dbname) or die("Error " . mysqli_error($connection));
+$query = "SELECT * from emails" or die("Error in the consult.." . mysqli_error($connection));
+echo "Here is the list of emails sent: <br>";
+$rs = $connection->query($query);
+while ($row = mysqli_fetch_assoc($rs)) {
+    echo "From Address: ".$row['from_add'] . "To Address: " . $row['to_add'] . "Subject: " . $row['subject'] ."When: ".$row['created_at'] . "<br>";
+}
+echo "End of the list <br>";
+mysqli_close($connection);
+?>

--- a/python-email-api/sample.py
+++ b/python-email-api/sample.py
@@ -33,12 +33,12 @@ class EmailResource(object):
                 'JSON was incorrect.')
  
         resp.status = falcon.HTTP_202
-        #server = smtplib.SMTP('smtp.gmail.com', 587)
-        #server.starttls()
-        #server.login(os.getenv('GMAIL_USERNAME', 'node2test@gmail.com'), os.getenv('GMAIL_PASSWORD', 'Refresh@2015'))
+        server = smtplib.SMTP('smtp.gmail.com', 587)
+        server.starttls()
+        server.login(os.getenv('GMAIL_USERNAME', 'node2test@gmail.com'), os.getenv('GMAIL_PASSWORD', 'Refresh@2015'))
         msg = email_req['msg']
-        #server.sendmail(os.getenv('GMAIL_USERNAME', 'node2test@gmail.com'), email_req['to'], msg)
-        #server.quit()
+        server.sendmail(os.getenv('GMAIL_USERNAME', 'node2test@gmail.com'), email_req['to'], msg)
+        server.quit()
         config = {
           'user': os.getenv('MYSQL_USER', 'root'),
           'password': os.getenv('MYSQL_PASSWORD', ''),


### PR DESCRIPTION
I have added installscripts that makes it easy to deploy these services in order if we are quickly trying to set up for demos. These scripts also set up the env variables using configmaps which may be safer from the perspective of not sharing the gmail and twitter credentials. I also split out the projects to optionally deploy these services into multiple projects for complex use cases such as to demo network policies. 

This PR is optional. I am submitting it just to see if we want to keep the code consistent.